### PR TITLE
Fail the script if any command fails

### DIFF
--- a/install_test_visibility.sh
+++ b/install_test_visibility.sh
@@ -8,6 +8,8 @@
 
 # The variables are printed in the following format: variableName=variableValue
 
+set -e
+
 ARTIFACTS_FOLDER="${DD_TRACER_FOLDER:-$(pwd)/.datadog}"
 if ! mkdir -p $ARTIFACTS_FOLDER; then
   >&2 echo "Error: Cannot create folder: $ARTIFACTS_FOLDER"


### PR DESCRIPTION
### What does this PR do?

Sets the `-e` flag so that the script stops running if any step fails. Otherwise, the script would continue and the error could be missed.

If it was intended to not use `-e` (ie: it's intended for the script not to fail), then feel free to ignore this :) 