### PR TITLE
Add `DD_TRACE_ESM_IMPORT` to the set env vars

### DIFF
--- a/install_test_visibility.sh
+++ b/install_test_visibility.sh
@@ -71,12 +71,17 @@ install_js_tracer() {
   fi
 
   # Github Actions prohibit setting NODE_OPTIONS
-  local dd_trace_path="$ARTIFACTS_FOLDER/lib/node_modules/dd-trace/ci/init"
+  local dd_trace_ci_init_path="$ARTIFACTS_FOLDER/lib/node_modules/dd-trace/ci/init"
+  local dd_trace_register_path="$ARTIFACTS_FOLDER/lib/node_modules/dd-trace/register.js"
   if ! is_github_actions; then
-    echo "NODE_OPTIONS=$NODE_OPTIONS -r $dd_trace_path"
+    echo "NODE_OPTIONS=$NODE_OPTIONS -r $dd_trace_ci_init_path"
   else
-    echo "DD_TRACE_PACKAGE=$dd_trace_path"
+    echo "DD_TRACE_PACKAGE=$dd_trace_ci_init_path"
   fi
+  # We can't set the --import flag directly in NODE_OPTIONS since it's only compatible from Node.js>=20.6.0 and Node.js>=18.19,
+  # not even if !is_github_actions. 
+  # Additionally, it's not useful for test frameworks other than vitest, which is ESM first. 
+  echo "DD_TRACE_ESM_IMPORT=$dd_trace_register_path"
 
   echo "DD_TRACER_VERSION_JS=$(npm list -g dd-trace | grep dd-trace | awk -F@ '{print $2}')"
 }


### PR DESCRIPTION
### What does this PR do?

In addition to `DD_TRACE_PACKAGE`, we'll set `DD_TRACE_ESM_IMPORT`, which is the required flag for ESM-first test frameworks.

### Motivation

[Vitest is esm-first](https://github.com/vitest-dev/vitest?tab=readme-ov-file#features), and ESM packages require an additional option in `NODE_OPTIONS`. 

We can't simply set `DD_TRACE_PACKAGE` to `-r dd-trace/ci/init --import dd-trace/register.js` because:

1. the `--import` flag is not available for all supported versions of node.js. We could solve this by checking the node.js version and adding it only if it's supported, but it wouldn't fix problem 2.
2. the `--import` flag does nothing for frameworks other than vitest. I wouldn't like to add it for other frameworks, as it's unnecessary overhead and a potential source of issues (ESM support is pretty recent, so more likely to have problems).

So I've thought that a good alternative is to set `DD_TRACE_ESM_IMPORT` and ask the users of vitest to add an extra element in their `NODE_OPTIONS` (see [instructions](https://github.com/DataDog/test-visibility-github-action?tab=readme-ov-file#tracing-js-tests)):

```yaml
- name: Run tests
  shell: bash
  run: npm run test-ci
  env:
    # do this only for vitest tests!
    NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}
```


### Possible Drawbacks / Trade-offs

I realise this is far from ideal, but I can't think of an alternative. Open to ideas though. 

### Describe how to test/QA your changes

Do an e2e test with vitest.