### PR TITLE
Add optional input to allow fine-grained instrumentation of Java build systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The script parameters are
 - `DD_SET_TRACER_VERSION_JAVA`: (optional) Version of the Java tracer to install (without the `v` prefix, e.g. `1.37.1`). If not provided, the latest version is installed.
 - `DD_SET_TRACER_VERSION_JS`: (optional) Version of the JS tracer to install. If not provided, the latest version is installed.
 - `DD_SET_TRACER_VERSION_PYTHON`: (optional) Version of the Python tracer to install. If not provided, the latest version is installed.
+- `DD_INSTRUMENTATION_BUILD_SYSTEM_JAVA`: (optional) A hint for Java instrumentation to instrument a specific build system. Allowed values are `maven` and `gradle`. If not specified, all Java processes will be instrumented.
 
 The script will install the libraries and print the list of environment variables that should be set in order to enable Test Visibility. Example output:
 ```shell


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

By default the script updates the `JAVA_TOOL_OPTIONS` environment variables, which injects the tracer into any Java process started afterwards.
There are currently some unresolved issue in the Java tracer that lead to some utility processes (such as Byte Buddy agent external instrumentation) getting stuck.

This PR adds optional `DD_INSTRUMENTATION_BUILD_SYSTEM_JAVA` environment variable that lets the user tell the script to only instrument specific processes (such as Maven or Gradle builds).
This workaround will help to avoid instrumenting extra processes until the issues in the tracer are resolved.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->