### PR TITLE
Instrument Gradle Launcher instead of directly instrumenting Gradle Daemon (to preserve org.gradle.jvmargs if it is specified)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ variables:
   AWS_MAX_ATTEMPTS: 5 # retry AWS operations 5 times if they fail on network errors
   DATADOG_AGENT_BUILDERS: v9930706-ef9d493
   S3_CP_CMD: aws s3 cp --only-show-errors --region us-east-1 --sse AES256
-  SCRIPT_VERSION: 3
+  SCRIPT_VERSION: 4
 
 deploy:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS

--- a/install_test_visibility.sh
+++ b/install_test_visibility.sh
@@ -35,7 +35,7 @@ install_java_tracer() {
 
   case $DD_INSTRUMENTATION_BUILD_SYSTEM_JAVA in
     gradle)
-      echo "GRADLE_OPTS=-Dorg.gradle.jvmargs=-javaagent:$filepath_tracer $GRADLE_OPTS"
+      echo "GRADLE_OPTS=-javaagent:$filepath_tracer $GRADLE_OPTS"
       ;;
     maven)
       echo "MAVEN_OPTS=-javaagent:$filepath_tracer $MAVEN_OPTS"
@@ -56,7 +56,7 @@ install_java_tracer() {
       fi
       ;;
     *)
-      echo "GRADLE_OPTS=-Dorg.gradle.jvmargs=-javaagent:$filepath_tracer $GRADLE_OPTS"
+      echo "GRADLE_OPTS=-javaagent:$filepath_tracer $GRADLE_OPTS"
       echo "MAVEN_OPTS=-javaagent:$filepath_tracer $MAVEN_OPTS"
       echo "SBT_OPTS=-javaagent:$filepath_tracer $SBT_OPTS"
       echo "ANT_OPTS=-javaagent:$filepath_tracer $ANT_OPTS"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Updates instrumentation logic for Gradle so that the Java tracer is injected into the Gradle Launcher instead of the Gradle Daemon: injecting the tracer into the daemon required overwriting its `org.gradle.jvmargs` system property which cancelled out whatever settings the user specified for the Gradle Daemon JVM (see https://github.com/DataDog/dd-trace-java/pull/8001 for more details).

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->