### PR TITLE
Increase reliability in case of get_orchestrion_go_version function fails

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ variables:
   AWS_MAX_ATTEMPTS: 5 # retry AWS operations 5 times if they fail on network errors
   DATADOG_AGENT_BUILDERS: v9930706-ef9d493
   S3_CP_CMD: aws s3 cp --only-show-errors --region us-east-1 --sse AES256
-  SCRIPT_VERSION: 8
+  SCRIPT_VERSION: 9
 
 deploy:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS

--- a/install_test_visibility.sh
+++ b/install_test_visibility.sh
@@ -395,7 +395,7 @@ get_orchestrion_go_version() {
     if [ "$input_tag" == "latest" ]; then
         # Use curl with -sSf to ensure errors are caught and not output to stdout
         # Use grep and sed to extract the tag_name from the JSON response
-        tag=$(curl -sSf https://api.github.com/repos/datadog/orchestrion/releases/latest \
+        tag=$(curl -sSf -A "github-action" https://api.github.com/repos/datadog/orchestrion/releases/latest \
               | grep -o '"tag_name": *"[^"]*"' \
               | head -n 1 \
               | sed 's/"tag_name": *"\([^"]*\)"/\1/')
@@ -418,7 +418,7 @@ get_orchestrion_go_version() {
 
     # Fetch the go.mod file content using curl with -sSf
     local go_mod
-    go_mod=$(curl -sSf "$url")
+    go_mod=$(curl -sSf -A "github-action" "$url" || true)
     if [ -z "$go_mod" ]; then
         echo "Error: Could not retrieve go.mod from ${url}" >&2
         return 1
@@ -505,7 +505,7 @@ install_go_tracer() {
 
   # Try to retrieve the required Go version from orchestrion's go.mod file using the specified tag.
   local orchestrion_go_version
-  orchestrion_go_version=$(get_orchestrion_go_version "$DD_SET_TRACER_VERSION_GO")
+  orchestrion_go_version=$(get_orchestrion_go_version "$DD_SET_TRACER_VERSION_GO" || true)
   if [ $? -ne 0 ] || [ -z "$orchestrion_go_version" ]; then
       echo "Error: Could not retrieve the required Go version for orchestrion (tag: $DD_SET_TRACER_VERSION_GO)." >&2
       echo "Skipping orchestrion installation." >&2


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds a custom `user-agent` header in the curl command and also now if `get_orchestrion_go_version` fails the script handles error correctly.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The curl fails sometimes with a 403 error, requests to the github api requires an `user-agent`, by manually adding it fixes the issue.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->