### PR TITLE
[SDTEST-1754] Set DD_TRACER_VERSION_RUBY env variable after installing Ruby library

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ variables:
   AWS_MAX_ATTEMPTS: 5 # retry AWS operations 5 times if they fail on network errors
   DATADOG_AGENT_BUILDERS: v9930706-ef9d493
   S3_CP_CMD: aws s3 cp --only-show-errors --region us-east-1 --sse AES256
-  SCRIPT_VERSION: 9
+  SCRIPT_VERSION: 10
 
 deploy:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS

--- a/install_test_visibility.sh
+++ b/install_test_visibility.sh
@@ -287,7 +287,6 @@ is_gem_present() {
   fi
 }
 
-
 is_gem_datadog_version_compliant() {
   # if there is no datadog gem in the bundle, it's ok, we are going to add it
   if ! is_gem_present "datadog"; then

--- a/install_test_visibility.sh
+++ b/install_test_visibility.sh
@@ -287,6 +287,10 @@ is_gem_present() {
   fi
 }
 
+datadog_ci_gem_version() {
+  bundle info datadog | head -n 1 | awk -F '[()]' '{print $2}'
+}
+
 is_gem_datadog_version_compliant() {
   # if there is no datadog gem in the bundle, it's ok, we are going to add it
   if ! is_gem_present "datadog"; then
@@ -294,7 +298,7 @@ is_gem_datadog_version_compliant() {
   fi
 
   local datadog_version
-  datadog_version=$(bundle info datadog | head -n 1 | awk -F '[()]' '{print $2}')
+  datadog_version=$(datadog_ci_gem_version)
 
   local major_datadog_version
   local minor_datadog_version
@@ -384,6 +388,7 @@ install_ruby_tracer() {
   fi
 
   echo "RUBYOPT=-rbundler/setup -rdatadog/ci/auto_instrument"
+  echo "DD_TRACER_VERSION_RUBY=$(datadog_ci_gem_version)"
 }
 
 # Function to get the Go version from the go.mod file of a release

--- a/install_test_visibility.sh
+++ b/install_test_visibility.sh
@@ -287,9 +287,6 @@ is_gem_present() {
   fi
 }
 
-datadog_ci_gem_version() {
-  bundle info datadog | head -n 1 | awk -F '[()]' '{print $2}'
-}
 
 is_gem_datadog_version_compliant() {
   # if there is no datadog gem in the bundle, it's ok, we are going to add it
@@ -298,7 +295,7 @@ is_gem_datadog_version_compliant() {
   fi
 
   local datadog_version
-  datadog_version=$(datadog_ci_gem_version)
+  datadog_version=$(bundle info datadog | head -n 1 | awk -F '[()]' '{print $2}')
 
   local major_datadog_version
   local minor_datadog_version
@@ -311,13 +308,17 @@ is_gem_datadog_version_compliant() {
   fi
 }
 
+datadog_ci_gem_version() {
+  bundle info datadog-ci | head -n 1 | awk -F '[()]' '{print $2}'
+}
+
 is_datadog_ci_version_compliant() {
   if ! is_gem_present "datadog-ci"; then
     return 1
   fi
 
   local datadog_ci_version
-  datadog_ci_version=$(bundle info datadog-ci | head -n 1 | awk -F '[()]' '{print $2}')
+  datadog_ci_version=$(datadog_ci_gem_version)
 
   local major_datadog_ci_version
   local minor_datadog_ci_version


### PR DESCRIPTION
### What does this PR do?

Sets DD_TRACER_VERSION_RUBY env variable after installing Ruby library

### Motivation

Fixes: https://github.com/DataDog/test-visibility-install-script/issues/18

### Describe how to test/QA your changes
Run in https://github.com/anmarchenko/quotes-rails and inspect output

Expected result:
<img width="568" alt="image" src="https://github.com/user-attachments/assets/3eb4f3d7-6a74-4f71-8ca9-d9688c66632d" />


