### PR TITLE
chore: pin GHA to full-length sha and pin coverage version

### DIFF
--- a/.github/workflows/go-test-matrix.yml
+++ b/.github/workflows/go-test-matrix.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Verify shell syntax
         run: |

--- a/.github/workflows/go-test-matrix.yml
+++ b/.github/workflows/go-test-matrix.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Verify shell syntax
         run: |

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The script parameters are
 - `DD_SET_TRACER_VERSION_JAVA`: (optional) Version of the Java tracer to install (without the `v` prefix, e.g. `1.37.1`). If not provided, the latest version is installed.
 - `DD_SET_TRACER_VERSION_JS`: (optional) Version of the JS tracer to install. If not provided, the latest version is installed.
 - `DD_SET_TRACER_VERSION_PYTHON`: (optional) Version of the Python tracer to install. If not provided, the latest version is installed.
+- `DD_SET_COVERAGE_VERSION_PYTHON`: (optional) Version of the Python `coverage` package to install. Defaults to `7.13.5`.
 - `DD_SET_TRACER_VERSION_RUBY`: (optional) Version of the Ruby datadog-ci gem to install. If not provided, the latest version is installed.
 - `DD_SET_TRACER_VERSION_GO`: (optional) Version of Orchestrion to install. If not provided, the latest version is installed.
 - `DD_CIVISIBILITY_GO_MODULE_DIR`: (optional) Directory that contains the Go project's `go.mod` file. Use this when the Go module is not at the repository root or when the repository contains multiple Go modules.

--- a/install_test_visibility.sh
+++ b/install_test_visibility.sh
@@ -197,7 +197,7 @@ install_python_tracer() {
     source .dd_civis_env/bin/activate >&2
   fi
 
-  if ! pip install -U ddtrace${DD_SET_TRACER_VERSION_PYTHON:+==$DD_SET_TRACER_VERSION_PYTHON} coverage >&2; then
+  if ! pip install -U ddtrace${DD_SET_TRACER_VERSION_PYTHON:+==$DD_SET_TRACER_VERSION_PYTHON} coverage==${DD_SET_COVERAGE_VERSION_PYTHON:-7.13.5} >&2; then
     >&2 echo "Error: Could not install ddtrace for Python"
     return 1
   fi


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Pins GHA references to full-length SHA
- Pins `coverage` version during Python installation to the current latest version `7.13.5`
- Adds a new configuration key `DD_SET_COVERAGE_VERSION_PYTHON` to allow a different version of the `coverage` package to be used